### PR TITLE
ci: make the required check name explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
         run: scripts/ci/redis-"$REDIS_MODE".sh down
 
   required:
+    name: CI / required
     if: always()
     needs:
       - pr-title


### PR DESCRIPTION
GitHub registers a job's explicit `name` as the required-check context. Set the stable gate to `CI / required` before the branch ruleset is installed.

Verified with actionlint.