### PR TITLE
fix(license): correct missing attribution for the original author

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2023 Insidious Fiddler
+Copyright (c) 2024-present Insidious Fiddler
+Copyright (c) 2023 hellosekai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Believe I missed this a while back when renaming some parts. Need to fix that so the license is actually correct.